### PR TITLE
.travis.yml - remove allow_failures about PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ php:
   - 5.4
   - 5.5
 
-matrix:
-  allow_failures:
-    - php: 5.5
-
 before_install:
   - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
   - cp tests/TestConfiguration.php.dist tests/TestConfiguration.php


### PR DESCRIPTION
PHP 5.5 stable is already released.
