### PR TITLE
Return the worker instance

### DIFF
--- a/src/mwGearman/Worker/Pecl.php
+++ b/src/mwGearman/Worker/Pecl.php
@@ -69,6 +69,8 @@ class Pecl extends AbstractPecl implements WorkerInterface
                 $this->register($f, array($this, 'proxify'));
             }
         }
+        
+        return $this->worker;
     }
 
     /**


### PR DESCRIPTION
In the function getGearmanWorker, you need to return the instance of the GearmanWorker
